### PR TITLE
Explicit dispose method detection

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="WithAttributeToBeRemoved.cs" />
+    <Compile Include="WithExplicitDisposeMethod.cs" />
     <Compile Include="WithUnmanagedAndDisposableField.cs" />
     <Compile Include="DisposeInBase\Child.cs" />
     <Compile Include="DisposeInBase\Parent.cs" />

--- a/AssemblyToProcess/WithExplicitDisposeMethod.cs
+++ b/AssemblyToProcess/WithExplicitDisposeMethod.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.IO;
+
+public class WithExplicitDisposeMethod:IDisposable
+{
+    void IDisposable.Dispose()
+    {
+    }
+}

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -26,7 +26,7 @@ public partial class ModuleWeaver
                 !x.CustomAttributes.ContainsSkipWeaving()))
         {
             var disposeMethods = type.Methods
-                                     .Where(x => !x.IsStatic && x.Name == "Dispose")
+                                     .Where(x => !x.IsStatic && (x.Name == "Dispose" || x.Name == "System.IDisposable.Dispose"))
                                      .ToList();
             if (disposeMethods.Count == 0)
             {

--- a/Fody/ModuleWeaverTests.cs
+++ b/Fody/ModuleWeaverTests.cs
@@ -24,6 +24,17 @@ public class ModuleWeaverTests
     }
 
     [Test]
+    public void EnsureExplicitDisposeMethodIsWeaved()
+    {
+        var instance = GetInstance("WithExplicitDisposeMethod");
+        var isDisposed = GetIsDisposed(instance);
+        Assert.IsFalse(isDisposed);
+        ((IDisposable)instance).Dispose();
+        isDisposed = GetIsDisposed(instance);
+        Assert.IsTrue(isDisposed);
+    }
+
+    [Test]
     public void EnsurePublicPropertyThrows()
     {
         var instance = GetInstance("Simple");


### PR DESCRIPTION
Fixes issue where an explicit definition of the `Dispose` method was not being picked up by Janitor.
