### PR TITLE
Hide dispose check IL from debugger

### DIFF
--- a/Fody/CecilExtensions.cs
+++ b/Fody/CecilExtensions.cs
@@ -131,4 +131,27 @@ public static class CecilExtensions
 
         return false;
     }
+
+    public static void HideLineFromDebugger(this Instruction i, SequencePoint seqPoint)
+    {
+        if (seqPoint == null)
+            return;
+
+        HideLineFromDebugger(i, seqPoint.Document);
+    }
+
+    public static void HideLineFromDebugger(this Instruction i, Document doc)
+    {
+        if (doc == null)
+            return;
+
+        // This tells the debugger to ignore and step through
+        // all the following instructions to the next instruction
+        // with a valid SequencePoint. That way IL can be hidden from
+        // the Debugger. See
+        // http://blogs.msdn.com/b/abhinaba/archive/2005/10/10/479016.aspx
+        i.SequencePoint = new SequencePoint(doc);
+        i.SequencePoint.StartLine = 0xfeefee;
+        i.SequencePoint.EndLine = 0xfeefee;
+    }
 }

--- a/Fody/TypeProcessor.cs
+++ b/Fody/TypeProcessor.cs
@@ -218,6 +218,9 @@ public class TypeProcessor
             {
                 continue;
             }
+
+            var validSequencePoint = method.Body.Instructions.Select(i => i.SequencePoint).FirstOrDefault(sp => sp != null);
+
             method.Body.SimplifyMacros();
             var instructions = method.Body.Instructions;
             instructions.InsertAtStart(new[]
@@ -225,6 +228,8 @@ public class TypeProcessor
                                            Instruction.Create(OpCodes.Ldarg_0),
                                            Instruction.Create(OpCodes.Call, throwIfDisposed),
                                        });
+            if (validSequencePoint != null)
+                instructions[0].HideLineFromDebugger(validSequencePoint);
             method.Body.OptimizeMacros();
         }
     }


### PR DESCRIPTION
This is the same issue NullGuard had, as described in Fody/Fody#102.

Improved debugger support for ignoring the dispose check added to the top of methods.
