### PR TITLE
Thread safer disposal of fields.

### DIFF
--- a/AssemblyToProcess/WithExplicitDisposeMethod.cs
+++ b/AssemblyToProcess/WithExplicitDisposeMethod.cs
@@ -1,8 +1,17 @@
 ﻿using System;
 
-public class WithExplicitDisposeMethod:IDisposable
+public class WithExplicitDisposeMethod : IDisposable
 {
+    public Explicit Child = new Explicit();
+
     void IDisposable.Dispose()
     {
+    }
+
+    public class Explicit : IDisposable
+    {
+        void IDisposable.Dispose()
+        {
+        }
     }
 }

--- a/Fody/CecilExtensions.cs
+++ b/Fody/CecilExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Anotar.Custom;
@@ -205,5 +206,20 @@ public static class CecilExtensions
     public static OpCode GetCallingConvention(this MethodReference method)
     {
         return method.Resolve().IsVirtual ? OpCodes.Callvirt : OpCodes.Call;
+    }
+
+    public static MethodReference MakeGeneric(this MethodReference method, params TypeReference[] args)
+    {
+        if (args.Length == 0)
+            return method;
+
+        if (method.GenericParameters.Count != args.Length)
+            throw new ArgumentException("Invalid number of generic type arguments supplied");
+
+        var genericTypeRef = new GenericInstanceMethod(method);
+        foreach (var arg in args)
+            genericTypeRef.GenericArguments.Add(arg);
+
+        return genericTypeRef;
     }
 }

--- a/Fody/ModuleWeaverTests.cs
+++ b/Fody/ModuleWeaverTests.cs
@@ -28,11 +28,16 @@ public class ModuleWeaverTests
     public void EnsureExplicitDisposeMethodIsWeaved()
     {
         var instance = GetInstance("WithExplicitDisposeMethod");
+        var child = instance.Child;
         var isDisposed = GetIsDisposed(instance);
+        var isChildDisposed = GetIsDisposed(child);
         Assert.IsFalse(isDisposed);
+        Assert.IsFalse(isChildDisposed);
         ((IDisposable)instance).Dispose();
         isDisposed = GetIsDisposed(instance);
+        isChildDisposed = GetIsDisposed(child);
         Assert.IsTrue(isDisposed);
+        Assert.IsTrue(isChildDisposed);
     }
 
     [Test]

--- a/Fody/ReferenceFinder.cs
+++ b/Fody/ReferenceFinder.cs
@@ -19,8 +19,7 @@ public partial class ModuleWeaver
 
         var interlockedTypeDefinition = msCoreTypes.First(x => x.Name == "Interlocked");
         ExchangeIntMethodReference = ModuleDefinition.ImportReference(interlockedTypeDefinition.Find("Exchange", "Int32&", "Int32"));
-        ExchangeTMethodReference = ModuleDefinition.ImportReference(interlockedTypeDefinition.Find("Exchange", "T&", "T"))
-            .MakeGeneric(ModuleDefinition.ImportReference(iDisposableTypeDefinition));
+        ExchangeTMethodReference = ModuleDefinition.ImportReference(interlockedTypeDefinition.Find("Exchange", "T&", "T"));
 
         var exceptionTypeDefinition = msCoreTypes.First(x => x.Name == "ObjectDisposedException");
         ExceptionConstructorReference = ModuleDefinition.ImportReference(exceptionTypeDefinition.Find(".ctor", "String"));

--- a/Fody/ReferenceFinder.cs
+++ b/Fody/ReferenceFinder.cs
@@ -3,7 +3,6 @@ using Mono.Cecil;
 
 public partial class ModuleWeaver
 {
-
     public void FindCoreReferences()
     {
         var assemblyResolver = ModuleDefinition.AssemblyResolver;
@@ -14,18 +13,21 @@ public partial class ModuleWeaver
 
         var gcTypeDefinition = msCoreTypes.First(x => x.Name == "GC");
         SuppressFinalizeMethodReference = ModuleDefinition.ImportReference(gcTypeDefinition.Find("SuppressFinalize", "Object"));
-        
-        var interlockedTypeDefinition = msCoreTypes.First(x => x.Name == "Interlocked");
-        ExchangeMethodReference = ModuleDefinition.ImportReference(interlockedTypeDefinition.Find("Exchange", "Int32&", "Int32"));
-
-        var exceptionTypeDefinition = msCoreTypes.First(x => x.Name == "ObjectDisposedException");
-        ExceptionConstructorReference = ModuleDefinition.ImportReference(exceptionTypeDefinition.Find(".ctor", "String"));
 
         var iDisposableTypeDefinition = msCoreTypes.First(x => x.Name == "IDisposable");
         DisposeMethodReference = ModuleDefinition.ImportReference(iDisposableTypeDefinition.Find("Dispose"));
+
+        var interlockedTypeDefinition = msCoreTypes.First(x => x.Name == "Interlocked");
+        ExchangeIntMethodReference = ModuleDefinition.ImportReference(interlockedTypeDefinition.Find("Exchange", "Int32&", "Int32"));
+        ExchangeTMethodReference = ModuleDefinition.ImportReference(interlockedTypeDefinition.Find("Exchange", "T&", "T"))
+            .MakeGeneric(ModuleDefinition.ImportReference(iDisposableTypeDefinition));
+
+        var exceptionTypeDefinition = msCoreTypes.First(x => x.Name == "ObjectDisposedException");
+        ExceptionConstructorReference = ModuleDefinition.ImportReference(exceptionTypeDefinition.Find(".ctor", "String"));
     }
 
-    public MethodReference ExchangeMethodReference;
+    public MethodReference ExchangeIntMethodReference;
+    public MethodReference ExchangeTMethodReference;
     public MethodReference SuppressFinalizeMethodReference;
     public MethodReference ObjectFinalizeReference;
     public MethodReference DisposeMethodReference;

--- a/Fody/TypeProcessor.cs
+++ b/Fody/TypeProcessor.cs
@@ -173,12 +173,15 @@ public class TypeProcessor
                 continue;
             }
 
+            var exchangedMethodReference = ModuleWeaver.ExchangeTMethodReference
+                .MakeGeneric(ModuleWeaver.ModuleDefinition.ImportReference(field.FieldType));
+
             var br1 = Instruction.Create(OpCodes.Callvirt, ModuleWeaver.DisposeMethodReference);
             var br2 = Instruction.Create(OpCodes.Nop);
             yield return Instruction.Create(OpCodes.Ldarg_0);
             yield return Instruction.Create(OpCodes.Ldflda, field);
             yield return Instruction.Create(OpCodes.Ldnull);
-            yield return Instruction.Create(OpCodes.Call, ModuleWeaver.ExchangeTMethodReference);
+            yield return Instruction.Create(OpCodes.Call, exchangedMethodReference);
             yield return Instruction.Create(OpCodes.Dup);
             yield return Instruction.Create(OpCodes.Brtrue, br1);
             yield return Instruction.Create(OpCodes.Pop);

--- a/Fody/TypeProcessor.cs
+++ b/Fody/TypeProcessor.cs
@@ -174,7 +174,7 @@ public class TypeProcessor
             }
 
             var exchangedMethodReference = ModuleWeaver.ExchangeTMethodReference
-                .MakeGeneric(ModuleWeaver.ModuleDefinition.ImportReference(field.FieldType));
+                .MakeGeneric(field.FieldType);
 
             var br1 = Instruction.Create(OpCodes.Callvirt, ModuleWeaver.DisposeMethodReference);
             var br2 = Instruction.Create(OpCodes.Nop);


### PR DESCRIPTION
Ok. I have some concerns regarding the thread safety of the dispose code generated by Janitor. Take this for example:

    public void Dispose()
    {
        if (Interlocked.Exchange(ref this.disposeSignaled, 1) != 0)
        {
            return;
        }
        if (this.stream != null)
        {
            ((IDisposable)this.stream).Dispose();
            this.stream = null;
        }
        this.disposed = true;
    }

The first `if` only guarantees that multiple Dispose calls doesn't dispose more than once.

The guard for other methods is based on the `disposed` field, which isn't set until the end of this method.

Between `if (this.stream != null)` and `((IDisposable)this.stream).Dispose();` another method could set `stream` to null.

This PR would change the above code to the following.

    public void Dispose()
    {
        if (Interlocked.Exchange(ref this.disposeSignaled, 1) != 0)
        {
            return;
        }
        var temp = Interlocked.Exchange<IDisposable>(ref stream, null);
        if (temp != null)
        {
            temp.Dispose();
        }
        this.disposed = true;
    }

Now there's no way to ensure the user code handles the field in a threadsafe way but now the Dispose won't throw.