### PR TITLE
Do not dispose tasks

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -60,6 +60,7 @@
     <Compile Include="WithManagedAndUnmanaged.cs" />
     <Compile Include="WithOverriddenDispose.cs" />
     <Compile Include="WithProtectedDispose.cs" />
+    <Compile Include="WithTask.cs" />
     <Compile Include="WithTypeConstraint.cs" />
     <Compile Include="WithUnmanaged.cs" />
     <Compile Include="WithUnmanagedAndDisposableField.cs" />

--- a/AssemblyToProcess/WithTask.cs
+++ b/AssemblyToProcess/WithTask.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading.Tasks;
+
+public class WithTask : IDisposable
+{
+    public TaskCompletionSource<int> taskCompletionSource;
+    public Task<int> taskField;
+
+    public WithTask()
+    {
+        taskCompletionSource = new TaskCompletionSource<int>();
+        taskField = taskCompletionSource.Task;
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/Fody/TypeProcessor.cs
+++ b/Fody/TypeProcessor.cs
@@ -180,6 +180,11 @@ public class TypeProcessor
                 LogTo.Error("Could not add dispose for field '{0}' since it is marked as readonly. Change this field to not be readonly.", field.GetName());
                 continue;
             }
+            if (field.FieldType.FullName.StartsWith("System.Threading.Tasks.Task"))
+            {
+                // do not dispose tasks, see https://blogs.msdn.microsoft.com/pfxteam/2012/03/25/do-i-need-to-dispose-of-tasks/
+                continue;
+            }
 
             var exchangedMethodReference = ModuleWeaver.ExchangeTMethodReference
                 .MakeGeneric(field.FieldType);

--- a/Tests/ModuleWeaverTests.cs
+++ b/Tests/ModuleWeaverTests.cs
@@ -295,6 +295,16 @@ public class ModuleWeaverTests
         Assert.That(writer.ToString(), Is.EqualTo(expectedValue));
     }
 
+    [Test]
+    public void EnsureTasksAreNotDisposed()
+    {
+        var instance = GetInstance("WithTask");
+        instance.Dispose();
+        Assert.IsNotNull(instance.taskField);
+        instance.taskCompletionSource.SetResult(42);
+        Assert.That(instance.taskField.Result, Is.EqualTo(42));
+    }
+
     bool GetIsDisposed(dynamic instance)
     {
         Type type = instance.GetType();


### PR DESCRIPTION
We detected an issue where disposal of a class fails because an unfinished Task was disposed. We excluded that task field as it seems that disposing tasks is an unnecessary operation (https://blogs.msdn.microsoft.com/pfxteam/2012/03/25/do-i-need-to-dispose-of-tasks/) which, as described, can even cause the disposal of a class to fail with an `InvalidOperationException` (https://msdn.microsoft.com/en-us/library/dd270681(v=vs.110).aspx)

Are there some additional test cases which would make sense?
Is there a better way to check for the field to be of type `Task` or `Task<>`?
Do I need to call `Resolve()` before accessing the `FullName` (as it's done in `IsIDisposable()`)?

ping @SimonCropp 