### PR TITLE
Skip namespace

### DIFF
--- a/AssemblyToProcess/AssemblyInfo.cs
+++ b/AssemblyToProcess/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Janitor.Fody;
+
+[assembly: SkipWeavingNamespace("NamespaceToSkip")]

--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -47,6 +47,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="DisposeInBase\Child.cs" />
     <Compile Include="DisposeInBase\Parent.cs" />
     <Compile Include="Simple.cs" />
@@ -54,6 +55,7 @@
     <Compile Include="WhereFieldIsDisposableClassArray.cs" />
     <Compile Include="WhereFieldIsIDisposable.cs" />
     <Compile Include="WhereFieldIsIDisposableArray.cs" />
+    <Compile Include="WhereNamespaceShouldBeSkipped.cs" />
     <Compile Include="WithAttributeToBeRemoved.cs" />
     <Compile Include="WithExplicitDisposeMethod.cs" />
     <Compile Include="WithManaged.cs" />

--- a/AssemblyToProcess/WhereNamespaceShouldBeSkipped.cs
+++ b/AssemblyToProcess/WhereNamespaceShouldBeSkipped.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.IO;
+
+namespace NamespaceToSkip
+{
+    public class WhereNamespaceShouldBeSkipped:IDisposable
+    {
+        public MemoryStream disposableField = new MemoryStream();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/ReferenceAssemblyNetStandard/ReferenceAssemblyNetStandard.csproj
+++ b/ReferenceAssemblyNetStandard/ReferenceAssemblyNetStandard.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />
     <Compile Include="..\ReferenceAssemblyPortable\SkipWeaving.cs" Link="SkipWeaving.cs" />
+    <Compile Include="..\ReferenceAssemblyPortable\SkipWeavingNamespace.cs" Link="SkipWeavingNamespace.cs" />
   </ItemGroup>
 
 </Project>

--- a/ReferenceAssemblyPortable/ReferenceAssembly.csproj
+++ b/ReferenceAssemblyPortable/ReferenceAssembly.csproj
@@ -40,6 +40,7 @@
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="SkipWeaving.cs" />
+    <Compile Include="SkipWeavingNamespace.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/ReferenceAssemblyPortable/SkipWeavingNamespace.cs
+++ b/ReferenceAssemblyPortable/SkipWeavingNamespace.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Janitor.Fody
+{
+    [AttributeUsage(
+        AttributeTargets.Assembly,
+        AllowMultiple = true)]
+    public sealed class SkipWeavingNamespace : Attribute
+    {
+        /// <summary>
+        /// Skips weaving for all types in the specified namespace.
+        /// </summary>
+        /// <param name="namespaceToSkip">The namespace which should be skipped.</param>
+        public SkipWeavingNamespace(string namespaceToSkip)
+        {
+            this.namespaceToSkip = namespaceToSkip;
+        }
+
+        private string namespaceToSkip;
+    }
+}

--- a/Tests/ModuleWeaverTests.cs
+++ b/Tests/ModuleWeaverTests.cs
@@ -306,6 +306,14 @@ public class ModuleWeaverTests
         Assert.That(instance.taskField.Result, Is.EqualTo(42));
     }
 
+    [Test]
+    public void EnsureClassesInSkippedNamespacesAreNotDisposed()
+    {
+        var instance = GetInstance("NamespaceToSkip.WhereNamespaceShouldBeSkipped");
+        instance.Dispose();
+        Assert.IsNotNull(instance.disposableField);
+    }
+
     bool GetIsDisposed(dynamic instance)
     {
         Type type = instance.GetType();


### PR DESCRIPTION
relates to https://github.com/Fody/Janitor/issues/20

adds an assembly level `SkipWeavingNamespace` attribute which allows to define entire namespaces to be skipped for weaving.