### PR TITLE
Add .NET Standard 2.0 assembly to ReferenceFinder

### DIFF
--- a/Fody/ReferenceFinder.cs
+++ b/Fody/ReferenceFinder.cs
@@ -10,6 +10,7 @@ public partial class ModuleWeaver
         AddAssemblyIfExists("mscorlib", types);
         AddAssemblyIfExists("System.Runtime", types);
         AddAssemblyIfExists("System.Threading", types);
+        AddAssemblyIfExists("netstandard", types);
 
         ObjectFinalizeReference = ModuleDefinition.ImportReference(ModuleDefinition.TypeSystem.Object.Resolve().Find("Finalize"));
 


### PR DESCRIPTION
This should let Janitor find the types it needs when being used from a .NET Standard 2.0 project.