### PR TITLE
fix for class with DisposeUnmanaged and generic field

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+end_of_line = crlf
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -51,6 +51,7 @@
     <Compile Include="DisposeInBase\Child.cs" />
     <Compile Include="DisposeInBase\Parent.cs" />
     <Compile Include="Simple.cs" />
+    <Compile Include="SimpleWithGenericField.cs" />
     <Compile Include="WhereFieldIsDisposableByBase.cs" />
     <Compile Include="WhereFieldIsDisposableClassArray.cs" />
     <Compile Include="WhereFieldIsIDisposable.cs" />
@@ -68,6 +69,7 @@
     <Compile Include="WithUnmanagedAndDisposableField.cs" />
     <Compile Include="WithUnmanagedAndGenericField.cs" />
     <Compile Include="WithUnmanagedAndGenericIDisposableField.cs" />
+    <Compile Include="WithUnmanagedAndGenericStreamField.cs" />
     <Compile Include="WithYield.cs" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -66,6 +66,8 @@
     <Compile Include="WithTypeConstraint.cs" />
     <Compile Include="WithUnmanaged.cs" />
     <Compile Include="WithUnmanagedAndDisposableField.cs" />
+    <Compile Include="WithUnmanagedAndGenericField.cs" />
+    <Compile Include="WithUnmanagedAndGenericIDisposableField.cs" />
     <Compile Include="WithYield.cs" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/AssemblyToProcess/SimpleWithGenericField.cs
+++ b/AssemblyToProcess/SimpleWithGenericField.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 
-public class WithUnmanagedAndGenericIDisposableField<T> : IDisposable
+public class SimpleWithGenericField<T> : IDisposable
     where T : IDisposable
 {
     public void Dispose()
-    {
-    }
-
-    void DisposeUnmanaged()
     {
     }
 

--- a/AssemblyToProcess/WithUnmanagedAndGenericField.cs
+++ b/AssemblyToProcess/WithUnmanagedAndGenericField.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+public class WithUnmanagedAndGenericField<T> : IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void DisposeUnmanaged()
+    {
+    }
+
+    public T Value { get; set; }
+}

--- a/AssemblyToProcess/WithUnmanagedAndGenericIDisposableField.cs
+++ b/AssemblyToProcess/WithUnmanagedAndGenericIDisposableField.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+public class WithUnmanagedAndGenericIDisposableField<T> : IDisposable
+    where T : class, IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    void DisposeUnmanaged()
+    {
+    }
+
+    public T Value { get; set; }
+}

--- a/AssemblyToProcess/WithUnmanagedAndGenericStreamField.cs
+++ b/AssemblyToProcess/WithUnmanagedAndGenericStreamField.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using System.IO;
 
-public class WithUnmanagedAndGenericIDisposableField<T> : IDisposable
-    where T : IDisposable
+public class WithUnmanagedAndGenericStreamField<T> : IDisposable
+    where T : Stream
 {
     public void Dispose()
     {

--- a/Fody/CecilExtensions.cs
+++ b/Fody/CecilExtensions.cs
@@ -61,6 +61,12 @@ public static class CecilExtensions
         {
             return false;
         }
+        if (typeRef.IsGenericParameter)
+        {
+            var genericParameter = (GenericParameter)typeRef;
+            return genericParameter.HasReferenceTypeConstraint &&
+                genericParameter.Constraints.Any(p => p.FullName.Equals("System.IDisposable"));
+        }
         var type = typeRef.Resolve();
         if (type.Interfaces.Any(i => i.InterfaceType.FullName.Equals("System.IDisposable")))
         {

--- a/Fody/CecilExtensions.cs
+++ b/Fody/CecilExtensions.cs
@@ -63,9 +63,7 @@ public static class CecilExtensions
         }
         if (typeRef.IsGenericParameter)
         {
-            var genericParameter = (GenericParameter)typeRef;
-            return genericParameter.HasReferenceTypeConstraint &&
-                genericParameter.Constraints.Any(p => p.FullName.Equals("System.IDisposable"));
+            return ((GenericParameter)typeRef).Constraints.Any(c => c.IsIDisposable());
         }
         var type = typeRef.Resolve();
         if (type.Interfaces.Any(i => i.InterfaceType.FullName.Equals("System.IDisposable")))
@@ -242,5 +240,15 @@ public static class CecilExtensions
             genericTypeRef.GenericArguments.Add(arg);
 
         return genericTypeRef;
+    }
+
+    public static TypeReference GetDisposable(this TypeReference reference)
+    {
+        if (reference.IsGenericParameter)
+        {
+            return ((GenericParameter)reference).Constraints.First(c => c.IsIDisposable());
+        }
+
+        return reference;
     }
 }

--- a/Fody/Processors/ManagedAndUnmanagedProcessor.cs
+++ b/Fody/Processors/ManagedAndUnmanagedProcessor.cs
@@ -25,7 +25,7 @@ public class ManagedAndUnmanagedProcessor
         instructions.Add(
             Instruction.Create(OpCodes.Ldarg_0),
             Instruction.Create(OpCodes.Ldc_I4_1),
-            Instruction.Create(OpCodes.Call, DisposeBoolMethod),
+            Instruction.Create(OpCodes.Call, DisposeBoolMethod.GetGeneric()),
             Instruction.Create(OpCodes.Ldarg_0),
             Instruction.Create(OpCodes.Call, TypeProcessor.ModuleWeaver.SuppressFinalizeMethodReference),
             Instruction.Create(OpCodes.Ret)

--- a/Fody/Processors/OnlyUnmangedProcessor.cs
+++ b/Fody/Processors/OnlyUnmangedProcessor.cs
@@ -20,7 +20,7 @@ public class OnlyUnmanagedProcessor
         instructions.Add(
             Instruction.Create(OpCodes.Ldarg_0),
             Instruction.Create(OpCodes.Ldc_I4_1),
-            Instruction.Create(OpCodes.Call, disposeBoolMethod),
+            Instruction.Create(OpCodes.Call, disposeBoolMethod.GetGeneric()),
             Instruction.Create(OpCodes.Ldarg_0),
             Instruction.Create(OpCodes.Call, TypeProcessor.ModuleWeaver.SuppressFinalizeMethodReference),
             Instruction.Create(OpCodes.Ret));

--- a/Fody/TypeProcessor.cs
+++ b/Fody/TypeProcessor.cs
@@ -26,7 +26,7 @@ public class TypeProcessor
         {
             disposeManagedMethod = CreateDisposeManagedIfNecessary();
         }
-        
+
         if (TargetType.FieldExists("disposeSignaled"))
         {
             ModuleWeaver.LogError($"Type `{TargetType.FullName}` contains a `disposeSignaled` field. Either remove this field or add a `[Janitor.SkipWeaving]` attribute to the type.");
@@ -201,7 +201,7 @@ public class TypeProcessor
             var br1 = Instruction.Create(OpCodes.Callvirt, ModuleWeaver.DisposeMethodReference);
             var br2 = Instruction.Create(OpCodes.Nop);
             yield return Instruction.Create(OpCodes.Ldarg_0);
-            yield return Instruction.Create(OpCodes.Ldflda, field);
+            yield return Instruction.Create(OpCodes.Ldflda, field.GetGeneric());
             yield return Instruction.Create(OpCodes.Ldnull);
             yield return Instruction.Create(OpCodes.Call, exchangedMethodReference);
             yield return Instruction.Create(OpCodes.Dup);

--- a/Fody/TypeProcessor.cs
+++ b/Fody/TypeProcessor.cs
@@ -196,7 +196,7 @@ public class TypeProcessor
             }
 
             var exchangedMethodReference = ModuleWeaver.ExchangeTMethodReference
-                .MakeGeneric(field.FieldType);
+                .MakeGeneric(field.FieldType.GetDisposable());
 
             var br1 = Instruction.Create(OpCodes.Callvirt, ModuleWeaver.DisposeMethodReference);
             var br2 = Instruction.Create(OpCodes.Nop);

--- a/Janitor.sln
+++ b/Janitor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 15.0.26403.7
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fody", "Fody\Fody.csproj", "{C3578A7B-09A6-4444-9383-0DEAFA4958BD}"
 EndProject
@@ -15,13 +15,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyWithReadOnly", "Ass
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{3AFB7D94-64AE-4E67-BF0B-C27588598395}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceAssemblyNetStandard", "ReferenceAssemblyNetStandard\ReferenceAssemblyNetStandard.csproj", "{BECA8B98-F5A1-419E-8BFE-81A77B3A17A3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReferenceAssemblyNetStandard", "ReferenceAssemblyNetStandard\ReferenceAssemblyNetStandard.csproj", "{BECA8B98-F5A1-419E-8BFE-81A77B3A17A3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nuget", "NuGet\Nuget.csproj", "{66DDADC1-1631-4EC7-8CB2-DD8080188234}"
 	ProjectSection(ProjectDependencies) = postProject
 		{6F416A34-2476-4A6B-B613-F9B46781C00D} = {6F416A34-2476-4A6B-B613-F9B46781C00D}
 		{C3578A7B-09A6-4444-9383-0DEAFA4958BD} = {C3578A7B-09A6-4444-9383-0DEAFA4958BD}
 		{BECA8B98-F5A1-419E-8BFE-81A77B3A17A3} = {BECA8B98-F5A1-419E-8BFE-81A77B3A17A3}
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3008950D-8740-4A99-9E93-A6EA3D6CF3A4}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
 Global
@@ -89,5 +94,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CDFD3F59-E969-4DA2-BFAE-1AF9D3E468E7}
 	EndGlobalSection
 EndGlobal

--- a/Tests/ModuleWeaverTests.cs
+++ b/Tests/ModuleWeaverTests.cs
@@ -81,9 +81,7 @@ public class ModuleWeaverTests
     [Test]
     public void WithTypeConstraint()
     {
-        var type = moduleWeaverTestHelper.Assembly.GetType("WithTypeConstraint`1", true);
-        var genericType = type.MakeGenericType(typeof(int));
-        var instance = (dynamic)Activator.CreateInstance(genericType);
+        var instance = GetGenericInstance("WithTypeConstraint`1", typeof(int));
         instance.Dispose();
     }
 
@@ -314,6 +312,24 @@ public class ModuleWeaverTests
         Assert.IsNotNull(instance.disposableField);
     }
 
+    [Test]
+    public void WithUnmanagedAndGenericField()
+    {
+        var instance = GetGenericInstance("WithUnmanagedAndGenericField`1", typeof(string));
+        Assert.That(GetIsDisposed(instance), Is.False);
+        instance.Dispose();
+        Assert.That(GetIsDisposed(instance), Is.True);
+    }
+
+    [Test]
+    public void WithUnmanagedAndGenericIDisposableField()
+    {
+        var instance = GetGenericInstance("WithUnmanagedAndGenericIDisposableField`1", typeof(Stream));
+        Assert.That(GetIsDisposed(instance), Is.False);
+        instance.Dispose();
+        Assert.That(GetIsDisposed(instance), Is.True);
+    }
+
     bool GetIsDisposed(dynamic instance)
     {
         Type type = instance.GetType();
@@ -337,6 +353,13 @@ public class ModuleWeaverTests
     {
         var type = moduleWeaverTestHelper.Assembly.GetType(className, true);
         return Activator.CreateInstance(type);
+    }
+
+    public dynamic GetGenericInstance(string className, params Type[] types)
+    {
+        var type = moduleWeaverTestHelper.Assembly.GetType(className, true);
+        var genericType = type.MakeGenericType(types);
+        return Activator.CreateInstance(genericType);
     }
 
     [Test]

--- a/Tests/ModuleWeaverTests.cs
+++ b/Tests/ModuleWeaverTests.cs
@@ -330,6 +330,24 @@ public class ModuleWeaverTests
         Assert.That(GetIsDisposed(instance), Is.True);
     }
 
+    [Test]
+    public void WithUnmanagedAndGenericStreamField()
+    {
+        var instance = GetGenericInstance("WithUnmanagedAndGenericStreamField`1", typeof(MemoryStream));
+        Assert.That(GetIsDisposed(instance), Is.False);
+        instance.Dispose();
+        Assert.That(GetIsDisposed(instance), Is.True);
+    }
+
+    [Test]
+    public void SimpleWithGenericField()
+    {
+        var instance = GetGenericInstance("SimpleWithGenericField`1", typeof(Stream));
+        Assert.That(GetIsDisposed(instance), Is.False);
+        instance.Dispose();
+        Assert.That(GetIsDisposed(instance), Is.True);
+    }
+
     bool GetIsDisposed(dynamic instance)
     {
         Type type = instance.GetType();


### PR DESCRIPTION
When a class has a generic field and only a DisposeUnmanaged method, the weaver throws the following exception:

```
Error		Fody: An unhandled exception occurred:
Exception:
Object reference not set to an instance of an object.
StackTrace:
   at CecilExtensions.IsIDisposable(TypeReference typeRef) in C:\projects\janitor\Fody\CecilExtensions.cs:line 64
   at TypeProcessor.<GetDisposeOfFieldInstructions>d__12.MoveNext() in C:\projects\janitor\Fody\TypeProcessor.cs:line 179
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at TypeProcessor.CreateDisposeManagedIfNecessary() in C:\projects\janitor\Fody\TypeProcessor.cs:line 131
   at TypeProcessor.Process() in C:\projects\janitor\Fody\TypeProcessor.cs:line 27
   at ModuleWeaver.Execute() in C:\projects\janitor\Fody\ModuleWeaver.cs:line 60
   at lambda_method(Closure , Object )
   at InnerWeaver.ExecuteWeavers() in C:\Code\Fody\Fody\FodyIsolated\InnerWeaver.cs:line 181
   at InnerWeaver.Execute() in C:\Code\Fody\Fody\FodyIsolated\InnerWeaver.cs:line 86
Source:
Janitor.Fody
TargetSite:
Boolean IsIDisposable(Mono.Cecil.TypeReference)
```

This PR fixes the issue.