### PR TITLE
Nested generated types not being skipped

### DIFF
--- a/AssemblyToProcess/WithDisposableLocalFunction.cs
+++ b/AssemblyToProcess/WithDisposableLocalFunction.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class WithDisposableLocalFunction
+{
+    public IEnumerable<string> MethodWithLocalFunction()
+    {
+        return ContainedTypes(typeof(IDictionary<int, string>)).ToList();
+
+        IEnumerable<string> ContainedTypes(Type type)
+        {
+            yield return type.FullName;
+
+            if (type.IsGenericType)
+            {
+                foreach (var containedType in
+                    type.GenericTypeArguments.SelectMany(ContainedTypes))
+                {
+                    yield return containedType;
+                }
+            }
+        }
+    }
+}

--- a/Janitor.Fody/CecilExtensions.cs
+++ b/Janitor.Fody/CecilExtensions.cs
@@ -146,7 +146,17 @@ public static class CecilExtensions
 
     public static bool IsGeneratedCode(this ICustomAttributeProvider value)
     {
-        return value.CustomAttributes.Any(a => a.AttributeType.Name == "CompilerGeneratedAttribute" || a.AttributeType.Name == "GeneratedCodeAttribute");
+        if (value == null)
+        {
+            return false;
+        }
+
+        if (value.CustomAttributes.Any(a => a.AttributeType.Name == "CompilerGeneratedAttribute" || a.AttributeType.Name == "GeneratedCodeAttribute"))
+        {
+            return true;
+        }
+
+        return IsGeneratedCode((value as TypeDefinition)?.DeclaringType);
     }
 
     public static bool IsEmptyOrNotImplemented(this MethodDefinition method)

--- a/Tests/ModuleWeaverTests.cs
+++ b/Tests/ModuleWeaverTests.cs
@@ -381,6 +381,15 @@ public class ModuleWeaverTests
         Assert.True(GetIsDisposed(instance));
     }
 
+    [Fact]
+    public void WithDisposableLocalFunction()
+    {
+        var instance = testResult.GetInstance("WithDisposableLocalFunction");
+        var types = instance.MethodWithLocalFunction();
+        Assert.NotNull(types);
+        Assert.NotEmpty(types);
+    }
+
     bool GetIsDisposed(dynamic instance)
     {
         Type type = instance.GetType();


### PR DESCRIPTION
I came across a situation in which the .Net compiler is not marking nested generated types as generated and running Janitor produces the following compile error:

```
Severity	Code	Description	Project	File	Line	Suppression State
Error		Fody/Janitor: Type `Sandbox.JanitorTests/<>c/<<InlineEnumerableTest>g__ContainedTypes|2_0>d` contains a `Dispose` method with code. Either remove the code or add a `[Janitor.SkipWeaving]` attribute to the type.	Sandbox			
```

This PR fixes the error.